### PR TITLE
Keep -p option with exclude_packages option

### DIFF
--- a/src/bloat.ts
+++ b/src/bloat.ts
@@ -76,7 +76,12 @@ export async function runCargoBloat(cargoPath: string, packageName: string): Pro
   let optionalArgs = core.getInput("bloat_args")
 
   if (optionalArgs.length > 0) {
-    bloatArgs = ["bloat", ...optionalArgs.split(' ')]
+    bloatArgs = [
+      "bloat",
+      ...optionalArgs.split(' '),
+      '-p',
+      packageName
+    ]
   }
   bloatArgs.push('--message-format=json', '-n', '0')
   const output = await captureOutput(cargoPath, bloatArgs)


### PR DESCRIPTION
The package option is missed when run  with `bloat_args` and `exclude_packages` at the same time.
This PR keeps the option.

Signed-off-by: Sangwan Kwon <sangwan.kwon@samsung.com>